### PR TITLE
Add support for `Reply-To` header

### DIFF
--- a/src/Transport/GraphApiTransport.php
+++ b/src/Transport/GraphApiTransport.php
@@ -76,6 +76,7 @@ class GraphApiTransport extends AbstractApiTransport
                 'toRecipients' => $this->normalizeAddresses($email->getTo()),
                 'ccRecipients' => $this->normalizeAddresses($email->getCc()),
                 'bccRecipients' => $this->normalizeAddresses($email->getBcc()),
+                'replyTo' => $this->normalizeAddresses($email->getReplyTo()),
                 'body' => $this->normalizeBody($email),
                 'attachments' => $this->normalizeAttachments($email),
             ],


### PR DESCRIPTION
Currently the library doesn't support setting the `Reply-To` header for emails. This header is especially helpful for confirmation messages where upon clicking "reply" ona message in an email client the recipient should differ from the original sender.

I added the `replyTo` message resource type property from the Graph API by reaming `$email->getReplyTo()`.