### PR TITLE
Use IDN-Encoded Addresses

### DIFF
--- a/src/Transport/GraphApiTransport.php
+++ b/src/Transport/GraphApiTransport.php
@@ -90,7 +90,7 @@ class GraphApiTransport extends AbstractApiTransport
     {
         $addressArray = [
             'emailAddress' => [
-                'address' => $address->getAddress(),
+                'address' => $address->getEncodedAddress(),
             ],
         ];
         if ($address->getName()) {


### PR DESCRIPTION
Currently, the raw address is used. If the domain contains non-ASCII characters, this may cause the mail to not get delivered.

In the encoded address, all non-ASCII-characters are encoded back to plain ASCII which is compatible with all SMTP servers.